### PR TITLE
fix: make asset and sw paths relative

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -6,9 +6,9 @@
   <title>Magen – Smärta, Kiss & Vätska</title>
 
   <!-- Ikoner -->
-  <link rel="icon" href="/favicon.png" sizes="64x64" type="image/png">
-  <link rel="apple-touch-icon" href="/apple-touch-icon.png" sizes="180x180">
-  <link rel="manifest" href="/manifest.webmanifest">
+  <link rel="icon" href="./favicon.png" sizes="64x64" type="image/png">
+  <link rel="apple-touch-icon" href="./apple-touch-icon.png" sizes="180x180">
+  <link rel="manifest" href="./manifest.webmanifest">
 
 <!-- (valfritt men bra på mobiler) -->
 <meta name="apple-mobile-web-app-capable" content="yes">

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -1574,7 +1574,7 @@ import '../styles/main.css';
     document.addEventListener('DOMContentLoaded', () => {
       App.init();
       if ('serviceWorker' in navigator) {
-        navigator.serviceWorker.register('/sw.js').catch(console.error);
+        navigator.serviceWorker.register(import.meta.env.BASE_URL + 'sw.js').catch(console.error);
       }
     });
 


### PR DESCRIPTION
## Summary
- use relative URLs for favicon, Apple icon, and manifest
- register service worker using `import.meta.env.BASE_URL`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b17104f9c08333b504a16f22454b93